### PR TITLE
Make gentoo kernel version determination more robust

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,13 @@
+#![feature(match_default_bindings)]
+#![feature(alloc_system)]
+
 extern crate reqwest;
 extern crate kuchiki;
 extern crate html5ever;
+extern crate semver;
 extern crate linuxver;
+
+use semver::Version;
 
 use std::thread;
 use kuchiki::traits::*;
@@ -13,14 +19,31 @@ fn get_request(s: &str) -> String {
     return body;
 }
 
+
 fn eval_css_selector(text: &str, css_selector: &str) -> String{
     let doc = kuchiki::parse_html().one(text);
     let css_match = doc.select_first(css_selector).unwrap();
     let as_node = css_match.as_node();
     let text_node = as_node.first_child().unwrap();
     let text = text_node.as_text().unwrap().borrow();
-    let formatted_text = format!("{:?}", text);
+    let formatted_text = format!("{}", text);
     return formatted_text;
+}
+
+fn eval_css_version_selector(text: &str, css_selector: &str) -> String {
+    let document = kuchiki::parse_html().one(text);
+    let latest_version_string = eval_css_selector(text, css_selector);
+    let mut latest_version = Version::parse(&latest_version_string).unwrap();
+    for css_match in document.select(css_selector).unwrap() {
+        let as_node = css_match.as_node();
+        let text_node = as_node.first_child().unwrap();
+        let text = text_node.as_text().unwrap().borrow();
+        let version = Version::parse(&text).unwrap();
+        if version > latest_version {
+            latest_version = version;
+        }
+    }
+    return latest_version.to_string();
 }
 
 fn get_version(url: &str, css_selector: &str) -> String {
@@ -29,31 +52,36 @@ fn get_version(url: &str, css_selector: &str) -> String {
     return css_result;
 }
 
+fn get_versions(url: &str, css_selector: &str) -> String {
+    let result = get_request(url);
+    let css_result = eval_css_version_selector(&result, css_selector);
+    return css_result;
+}
+
 fn main() {
     // TODO: Clean up parallelization
+    // TODO: more robust version detection.  Latest version isn't always the first on the page
     let gentoo = thread::spawn(|| {
-       let version = get_version(
+       let version= get_versions(
             "https://packages.gentoo.org/packages/sys-kernel/gentoo-sources",
-            "body > div.container > div > div > div > div.col-md-9\
-        > div:nth-child(1) > div.table-responsive > table > tbody\
-        > tr:nth-child(1) > td.kk-version.kk-cell-sep-right > strong > a");
+            "td.kk-version.kk-cell-sep-right > strong > a");
         println!("Gentoo: {}", version);
     });
 
-    // TODO: more robust version detection.  Latest version isn't always the first on the page
+    // TODO: more robust version detection.  stable (in the version table) isn't always the latest version, which might be shown under #latest_link, etc.
     let vanilla = thread::spawn(|| {
         let version = get_version("https://www.kernel.org", "#latest_link > a");
         println!("Vanilla: {}", version);
     });
 
-    // TODO: more robust version detection.  stable (in the version table) isn't always the latest version, which might be shown under #latest_link, etc.
     let local = thread::spawn(|| {
         let local_kernel = linuxver::version().unwrap();
         println!("Currently running kernel version: {}.{}.{}", local_kernel.major, local_kernel.minor, local_kernel.patch );
     });
 
-    vanilla.join();
-    gentoo.join();
-    local.join();
+    // #[warn(unused_must_use)] on by default
+    let _ = vanilla.join();
+    let _ = gentoo.join();
+    let _ = local.join();
 
 }


### PR DESCRIPTION
- Parses entire list of kernel versions on the Gentoo packages page and retrieves the highest kernel version, rather than looking for the first entry on the list, as this is not always the latest kernel
- Handle unused_must_use warnings